### PR TITLE
Fix rendering of car final positions.

### DIFF
--- a/src/racetrack.ts
+++ b/src/racetrack.ts
@@ -370,12 +370,13 @@ class Racetrack {
                 this.dot(...p, CAR_COLORS[i]);
             }
 
+            const [x, y] = scale(this.track.grid, car.position);
             if (car.status === 'crashed') {
-                this.dot(...car.position, 'yellow');
+                this.dot(x, y, 'yellow');
             }
 
             if (car.status === 'error') {
-                this.dot(...car.position, 'red');
+                this.dot(x, y, 'red');
             }
         }
     }


### PR DESCRIPTION
Right now they all get rendered in the top left since they're not getting scaled.

<img width="416" alt="image" src="https://user-images.githubusercontent.com/206364/224211357-4b6fa63d-f8ed-48da-bb26-62b9aa9bc480.png">
