### PR TITLE
Widen BIG_OVAL track and make sure edges don't fall on gridpoints.

### DIFF
--- a/src/tracks.ts
+++ b/src/tracks.ts
@@ -36,8 +36,8 @@ export const BIG_OVAL:Track = {
     name: "Big Oval",
     dim: [800, 400],
     grid: 10,
-    startLine: [[400, 20], [400, 60]],
-    finishLine: [[380, 20], [380, 60]],
-    trackWidth: 40,
+    startLine: [[400, 5], [400, 75]],
+    finishLine: [[380, 5], [380, 75]],
+    trackWidth: 70,
     path: [[400, 40], [760, 40], [760, 360], [40, 360], [40, 40], [380, 40]],
 }


### PR DESCRIPTION
Helps address #16.

Before:
![image](https://user-images.githubusercontent.com/206364/224524002-8da5f889-6de7-4ce2-a7b7-6d98b9fa486a.png)

After:
![image](https://user-images.githubusercontent.com/206364/224523997-7c2ec577-0509-4bdd-abf8-e4f4880b6f4d.png)
